### PR TITLE
ci: use renovate to update matrix OS runner

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,17 @@
     ":automergeMinor",
     ":automergeDigest"
   ],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^.github/(?:workflows|actions)/.+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "os: \"(?<currentValue>.*?)\""
+      ],
+      "datasourceTemplate": "github-runners"
+    }
+  ]
 }


### PR DESCRIPTION
Automatically upgrade runners in workflows when using a matrix for os.