### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,18 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build_and_test:
     name: Build and test
     runs-on: ${{ matrix.config.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         config:
@@ -20,10 +28,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,84 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  changes:
+    name: Detect workflow changes
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      github: ${{ steps.filter.outputs.github }}
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            github:
+              - '.github/**'
+
+  lint:
+    name: Lint
+    needs: changes
+    if: needs.changes.outputs.github == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: "1.26.1"
+          advanced-security: false
+          annotations: true
+
+      - name: Run actionlint
+        env:
+          # renovate: datasource=github-releases depName=rhysd/actionlint
+          ACTIONLINT_VERSION: 1.7.12
+        run: |
+          curl -fsSL -o actionlint-matcher.json "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/.github/actionlint-matcher.json"
+          echo "::add-matcher::actionlint-matcher.json"
+          bash <(curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash") "${ACTIONLINT_VERSION}"
+          ./actionlint -color
+        shell: bash
+
+      - name: Verify actions are pinned
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          fix: "false"
+
+  gate:
+    name: Lint gate
+    if: always()
+    needs: [changes, lint]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check lint outcome
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+        run: |
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "Change detection did not succeed (result: $CHANGES_RESULT)"
+            exit 1
+          fi
+          if [ "$LINT_RESULT" = "failure" ] || [ "$LINT_RESULT" = "cancelled" ]; then
+            echo "Lint failed (result: $LINT_RESULT)"
+            exit 1
+          fi
+          echo "OK (changes: $CHANGES_RESULT, lint: $LINT_RESULT)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,18 +13,28 @@ on:
           - minor
           - major
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   release:
     name: Release
 
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -35,10 +45,12 @@ jobs:
         run: pnpm ci
 
       - name: Bump the package version
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           git config user.name 'Xavier Balloy'
           git config user.email '686305+xballoy@users.noreply.github.com'
-          pnpm version ${{ github.event.inputs.version }}
+          pnpm version "$VERSION"
 
       - name: Publish
         uses: lannonbr/vsce-action@510e61c5e9e6f33c0418ec5ff5fd36b1ced61e85 # 4.0.0
@@ -48,7 +60,10 @@ jobs:
           VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
 
       - name: Push
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}"
           git push
           git push --tags


### PR DESCRIPTION
## Overview

Security-hardening pass across all workflow files, closing the standard set of weaknesses flagged by `zizmor` / `actionlint`, plus a new lint workflow that keeps them enforced.

## Changes

- **Least-privilege permissions** — top-level `permissions: {}` on every workflow; `build.yml` runs with `contents: read`, the publish job with `contents: write` (needed for the version-bump commit/tags push).
- **Concurrency guards** — cancel superseded runs except on `main` (`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`).
- **No persisted checkout credentials** — `persist-credentials: false` on every `actions/checkout`; the publish push sets its own token-authenticated remote so it doesn't rely on persisted credentials.
- **Injection-safe / secret-safe `run` steps** — the version input, `GITHUB_TOKEN`, and `github.repository` are moved out of inline `${{ }}` interpolation into `env:` and referenced as quoted variables.
- **Full pin comments** — normalized abbreviated pin tags to exact versions.
- **New `lint-actions.yml`** — runs `zizmor` + `actionlint` + `pinact` on `.github/**` changes, behind a fail-closed `gate` job that acts as a stable required status check.

## Testing

- The build matrix (Linux/macOS/Windows) and `Lint GitHub Actions` run on this PR exercise the changes. Verified locally clean with `actionlint`, `zizmor --min-severity low --min-confidence medium`, and `pinact run --check --verify`.
- **Publish flow** (not exercised by this PR): after merge, run `Publish to Marketplace` via `workflow_dispatch` and confirm the version bump, marketplace publish, and token-based `git push` (commit + tags) all still work with the `env`-bound version/token and `contents: write` permission.
